### PR TITLE
Comments are the wrong format

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ the original Blurple is now a colour choice.
 
 ```scss
 :root {
-	// Monokai colours
+	/* Monokai colours */
 	--monokai-black: #1a1a1a;
 	--monokai-red: #f4005f;
 	--monokai-green: #98e024;
@@ -66,7 +66,8 @@ the original Blurple is now a colour choice.
 	--monokai-bright-white: #f6f6ef;
 	--monokai-background: #1a1a1a;
 	--monokai-foreground: #c4c5b5;
-	// Diskai colours
+	
+	/* Diskai colours */
 	--diskai-pink: #ff4d91;
 	--diskai-light-pink: #ffb3d0;
 	--diskai-lilac: #b26bff;
@@ -76,11 +77,11 @@ the original Blurple is now a colour choice.
 	--diskai-dark-green: #79b814;
 	--diskai-muted-white: #888;
 
-	// Very unimportant colours
-	// sad to see this one go and be replaced by #5865F2 :(
+	/* Very unimportant colours
+	sad to see this one go and be replaced by #5865F2 :( */
 	--old-blurple: #7289DA;
 	
-	// VERY IMPORTANT CUSTOMISATION VARIABLES
+	/* VERY IMPORTANT CUSTOMISATION VARIABLES */
 	--diskai-accent-colour: var(--diskai-dark-green);
 	--diskai-accent-contrast: var(--text-normal);
 	--diskai-mention-colour: var(--monokai-purple);


### PR DESCRIPTION
The comments for the root CSS use the wrong styling, this fixes it. I barely know any CSS so this messed me up when copying from the README